### PR TITLE
fixed typo discovered while shamelessly copying and pasting from the docs...

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ node fixtureFile.js
 To write a fixture file, begin with
 ```
 var fluid = require("infusion");
-var jqUnit = fluid.require(jqUnit); 
+var jqUnit = fluid.require("jqUnit"); 
 ```
 
 You may use also use plain "require" to load jqUnit, although it is essential that it itself may resolve the fluid framework (infusion).


### PR DESCRIPTION
In the fluid.require, jqUnit should be a string and not a variable.  Otherwise it's trying to reference itself while it's being defined.
